### PR TITLE
Update shairport-sync-3.3.9.ebuild

### DIFF
--- a/media-sound/shairport-sync/shairport-sync-3.3.9.ebuild
+++ b/media-sound/shairport-sync/shairport-sync-3.3.9.ebuild
@@ -23,7 +23,7 @@ RDEPEND="
 	dev-libs/libconfig
 	openssl? ( dev-libs/openssl )
 	mbedtls? ( net-libs/mbedtls )
-	net-dns/avahi
+	net-dns/avahi[mdnsresponder-compat]
 	soxr? ( media-libs/soxr )
 	alsa? ( media-libs/alsa-lib )
 	alac? ( media-libs/alac )


### PR DESCRIPTION
Fixed:
missing avahi-client libs, flag added